### PR TITLE
Update eve dependencies. (#18)

### DIFF
--- a/eve_auth_jwt/auth.py
+++ b/eve_auth_jwt/auth.py
@@ -101,7 +101,7 @@ class JWTAuth(BasicAuth):
         If the validation succeed, the claims are stored and accessible thru the
         get_authen_claims() method.
         """
-        resource_conf = config.DOMAIN[resource]
+        resource_conf = config.DOMAIN.get(resource, {})
         audiences = resource_conf.get('audiences', config.JWT_AUDIENCES)
         return self._perform_verification(token, audiences, allowed_roles)
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     keywords=['eve', 'api', 'rest', 'oauth', 'auth', 'jwt'],
     packages=['eve_auth_jwt'],
     package_dir={'eve_auth_jwt': 'eve_auth_jwt'},
-    install_requires=['eve>=0.7.5', 'pyjwt==1.5.3'],
+    install_requires=['eve>=0.7.5', 'pyjwt==1.7.1'],
     test_suite='test',
     tests_require=['flake8'],
     license='MIT',


### PR DESCRIPTION
* FIX: JWTAuth.check_token wont trigger a KeyError on resource less endpoints, such as  or custom endpoints

* Fixed dependency issue which causes newer versions of pip to fail.